### PR TITLE
handle empty lines within keywords.txt

### DIFF
--- a/shotlooter.py
+++ b/shotlooter.py
@@ -158,8 +158,10 @@ def action(code,imagedir,no_entropy,no_cc,no_keyword):
     keywords = []
     numbers = re.compile('\d+(?:\.\d+)?')
     with open("keywords.txt", "r") as f:
-        for line in f:
-            keywords.append(line.rstrip('\n').lower())
+        for line in f:    
+            line_rstripped = line.rstrip()
+            if line_rstripped:
+                keywords.append(line_rstripped.lower())
     while True:
         code = next_code(code)
         try:


### PR DESCRIPTION
Currently if empty lines are present within `keywords.txt`, every image scanned will create a match and you will come back 1 week later to find 50GBs of downloaded screenshots on your server.